### PR TITLE
fix : revert TextShape testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,8 @@ For trying to fix these problems, you can try:
 - use variable formatting instead of the one of the character before
 
 ## Versions :
+- v1.2.8, 2023-09-01 :
+  - fix bug in TextShape var replacement
 - v1.2.7, 2023-08-30 :
   - Upgrade to debian bookworm slim
 - v1.2.6, 2023-08-30 :

--- a/lotemplate/classes.py
+++ b/lotemplate/classes.py
@@ -968,9 +968,7 @@ class Template:
 
             for page in doc.getDrawPages():
                 for shape in page:
-                    # note : we changed this test in order to manage more possible shapes.
-                    # if shape.getShapeType() == "com.sun.star.drawing.TextShape":
-                    if hasattr(shape, 'String'):
+                    if shape.getShapeType() == "com.sun.star.drawing.TextShape":
                         shape.String = shape.String.replace(variable, value)
 
         def html_fill(doc, variable: str, value: str) -> None:
@@ -994,9 +992,7 @@ class Template:
 
             for page in doc.getDrawPages():
                 for shape in page:
-                    # note : we changed this test in order to manage more possible shapes.
-                    # if shape.getShapeType() == "com.sun.star.drawing.TextShape":
-                    if hasattr(shape, 'String'):
+                    if shape.getShapeType() == "com.sun.star.drawing.TextShape":
                         shape.String = shape.String.replace(variable, value)
                         # we wanted to use the pasteHtml function, but it doesn't work in a shape
                         # cursor = shape.createTextCursor()


### PR DESCRIPTION
*revert a test on TextShape*

### Changes
- *Fixed: revert a test on TextShape . The function hasattr is not working as attended*

### Checklist
- [ ] If code changed were made, they have been tested.
- [ ] This pull request fixes an issue.
- [ ] This pull request adds a feature.
- [ ] The code has been tested.
