### PR TITLE
Fix error on unsupported cell interfaces

### DIFF
--- a/lotemplate/Statement/TableStatement.py
+++ b/lotemplate/Statement/TableStatement.py
@@ -1,4 +1,5 @@
 from com.sun.star.lang import XComponent
+from com.sun.star.sheet import XCellRangeData
 from typing import Union
 import lotemplate.errors as errors
 import regex
@@ -46,7 +47,10 @@ class TableStatement:
         tab_vars = {}
         list_tab_vars = []
         for i in range(doc.getTextTables().getCount()):
-            table_data = doc.getTextTables().getByIndex(i).getDataArray()
+            table = doc.getTextTables().getByIndex(i)
+            if not isinstance(table, XCellRangeData):
+                continue
+            table_data = table.getDataArray()
             t_name = doc.getTextTables().getByIndex(i).getName()
             nb_rows = len(table_data)
             for row_i, row in enumerate(table_data):


### PR DESCRIPTION
The upload of some template files (probably edited by non-standard document editors) caused a 500 error `unsatisfied query for interface of type com.sun.star.sheet.XCellRangeData!`.
This was because the table was not using the [XCellRangeData standard interface](https://www.openoffice.org/api/docs/common/ref/com/sun/star/sheet/XCellRangeData.html) so I added a check using the `com.sun.star.sheet` module.

### Changes
- *Added a check on the format of a table before querying its data*

### Checklist
- [x] If code changed were made, they have been tested.
- [ ] This pull request fixes an issue.
- [ ] This pull request adds a feature.
- [x] The code has been tested.
