### PR TITLE
Sort variable to avoid sub string replacement

### DIFF
--- a/lotemplate/Statement/CalcTableStatement.py
+++ b/lotemplate/Statement/CalcTableStatement.py
@@ -96,7 +96,7 @@ class CalcTableStatement:
             copycell=sheet.getCellByPosition(StartColumn,StartRow)
             rangetocopy=sheet.getCellRangeByPosition(StartColumn,StartRow,EndColumn,EndRow )
             sheet.copyRange(copycell.CellAddress,doc.NamedRanges.getByName(variable).getReferredCells().getRangeAddress())
-            for key, mylist  in value.items():
+            for key, mylist  in sorted(value.items(), key=lambda x: len(x[0]), reverse=True):
                 try:
                     CalcTextStatement.fill(rangetocopy,'&'+key,mylist['value'][i])
                 except IndexError:


### PR DESCRIPTION
### Description

In the CalcTableStatement, in the case of variables that share the same starting sub-string, the sub-string was replaced corrupting the next ones

Example where :
$var -> "MyVariable"
$var_corrupted -> "ERROR"

When replacing
$var -> "MyVariable"
$var_corrupted -> "MyVariable_corrupted" instead of "ERROR"

### Changes

I sorted the value by length so the problem could not occur since we replace the longer strings first there is no possibility of substring being replaced

### Checklist
- [X] This pull request fixes an issue.
